### PR TITLE
New style for '::set-output'

### DIFF
--- a/.github/workflows/rust_publish.yml
+++ b/.github/workflows/rust_publish.yml
@@ -26,7 +26,8 @@ jobs:
 
     - name: Get version from github ref
       id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      run: echo "{VERSION}={${GITHUB_REF/refs\/tags\//}}" >> $GITHUB_OUTPUT
+
 
     - name: Build and push
       uses: docker/build-push-action@v3
@@ -42,7 +43,7 @@ jobs:
     steps:
     - name: Get version from github ref
       id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      run: echo "{VERSION}={${GITHUB_REF/refs\/tags\//}}" >> $GITHUB_OUTPUT
 
     - name: Login via Azure CLI
       uses: azure/login@v1


### PR DESCRIPTION
Github has done some updates, and this is is a warning, see:
   https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

> ```Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/```

---

Second warning:
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions-rs/toolchain@v1

Not attended, as there is no update of `actions-rs/toolchain@v1`, seems to be a stale project.
https://github.com/actions-rs/toolchain/issues/219