### PR TITLE
feat: add reviewers and grouping for non-major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,15 +10,36 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    reviewers:
+      - "kazie"
+    groups:
+      non-major-updates:
+        patterns:
+          - "minor"
+          - "patch"
 
   # Maintain dependencies in dockerfiles
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
+    reviewers:
+      - "kazie"
+    groups:
+      non-major-updates:
+        patterns:
+          - "minor"
+          - "patch"
 
   # Maintain dependencies in cargo and cargo-lock
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "daily"
+    reviewers:
+      - "kazie"
+    groups:
+      non-major-updates:
+        patterns:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Added "kazie" as a reviewer and created groups for non-major updates in Dependabot configuration. This ensures minor and patch updates are grouped and reviewed consistently across various ecosystems.