### PR TITLE
Rename dependabot group and add update patterns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,10 @@ updates:
     reviewers:
       - "kazie"
     groups:
-      non-major-updates:
+      minor-and-patch:
         patterns:
+          - "*"
+        update-types:
           - "minor"
           - "patch"
 
@@ -26,8 +28,10 @@ updates:
     reviewers:
       - "kazie"
     groups:
-      non-major-updates:
+      minor-and-patch:
         patterns:
+          - "*"
+        update-types:
           - "minor"
           - "patch"
 
@@ -39,7 +43,9 @@ updates:
     reviewers:
       - "kazie"
     groups:
-      non-major-updates:
+      minor-and-patch:
         patterns:
+          - "*"
+        update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
Renamed the group 'non-major-updates' to 'minor-and-patch' for clarity. Added patterns to specify that all minor and patch updates should be applied. This ensures consistent and clear labeling for dependency updates.