### PR TITLE
fix(config.yaml): correct company name in Easter egg hint

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -45,7 +45,7 @@ time_report:
     1:
       - "En sak som dock inte är nytt, är att det är slutet på månaden och det är dags att tidrapportera."
     3:
-      - "Ditt påskägg är gömt i ett av milltimes djupaste projekt. Gå och leta, men glöm inte tidsrapporten"
+      - "Ditt påskägg är gömt i ett av kleers djupaste projekt. Gå och leta, men glöm inte tidsrapporten"
     12:
       - "Från djupet av min beräkningsmodul: Kom ihåg att rapportera era tider för en God Jul! 🎅🎄"
 


### PR DESCRIPTION
Corrected the company name from "milltimes" to "kleers" in the Easter egg hint within the config.yaml file.